### PR TITLE
[BACK-13] Improve Create API Response for Container Null Fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ After run access to (http://localhost:8080/api-route)
 |--------|--------------------------|--------------------------------|------------------------------------|--------------------------------------------|---------------------------|-------------------------------------------------------------------------------------------------------------------------------|
 | POST   | /container/api/v1/create | Create Container               | Content-Type: application/json| ```{"code": "ABC", "status": "PICKED_UP"}``` | 201 Created               | `{"id": 1, "code": "ABC", "status": "PICKED_UP"}`                                                                             |
 | POST    | /container/api/v1/create | Create Container               | Content-Type: application/json| `{"code": "ABC", "status": "OTHER"}`       | 400 Bad Request           | `{"timestamp": "...", "status": 400, "error": "Bad Request", "message": "...", "path": "/container/api/v1/create"}`           |
-| POST    | /container/api/v1/create | Create Container - null fields | Content-Type: application/json| `{"code": "ABC"}`     | 500 Internal Server Error | `{"timestamp": "...", "status": 500, "error": "Internal Server Error", "message": "...", "path": "/container/api/v1/create"}` |
+| POST    | /container/api/v1/create | Create Container - null fields | Content-Type: application/json| `{"code": "ABC"}`     | 400 Bad Request  |  |
 
 
 #### Endpoint Detail Container example

--- a/src/main/java/com/practice/portcontainertrackingbackend/application/ContainerServiceImpl.java
+++ b/src/main/java/com/practice/portcontainertrackingbackend/application/ContainerServiceImpl.java
@@ -20,6 +20,9 @@ public class ContainerServiceImpl implements ContainerService {
 
     @Override
     public Container createContainer(Container container) {
+        if (container.getCode() == null || container.getStatus() == null) {
+            throw new IllegalArgumentException("Error in arguments");
+        }
         return containerRepository.save(container);
     }
 

--- a/src/main/java/com/practice/portcontainertrackingbackend/presentation/controllers/ContainerControllerImpl.java
+++ b/src/main/java/com/practice/portcontainertrackingbackend/presentation/controllers/ContainerControllerImpl.java
@@ -27,8 +27,16 @@ public class ContainerControllerImpl implements ContainerControllers {
 
     @Override
     public ResponseEntity<Container> createOrder(Container container) {
-        Container containerCreated = containerService.createContainer(container);
-        return new ResponseEntity<>(containerCreated, HttpStatus.CREATED);
+        try {
+            Container containerCreated = containerService.createContainer(container);
+            return new ResponseEntity<>(containerCreated, HttpStatus.CREATED);
+        } catch (IllegalArgumentException e) {
+            log.error("Bad request for create container", e);
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        } catch (Exception e) {
+            log.error("Unexpected error for create container", e);
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     @Override

--- a/src/test/java/com/practice/portcontainertrackingbackend/integration/presentation/ContainerControllerITests.java
+++ b/src/test/java/com/practice/portcontainertrackingbackend/integration/presentation/ContainerControllerITests.java
@@ -94,6 +94,19 @@ public class ContainerControllerITests extends AbstractionContainerBaseTests {
             // Then
             response.andExpect(status().isBadRequest());
         }
+
+        @Test
+        void shouldReturnBadRequest400WhenCreatingObjectWithNullFields() throws Exception {
+            // Given
+
+            // When
+            ResultActions response = mockMvc.perform(post(serviceCreateUrl)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"));
+
+            // Then
+            response.andExpect(status().isBadRequest());
+        }
     }
 
     @Nested

--- a/src/test/java/com/practice/portcontainertrackingbackend/unit/application/ContainerServiceTests.java
+++ b/src/test/java/com/practice/portcontainertrackingbackend/unit/application/ContainerServiceTests.java
@@ -64,7 +64,8 @@ public class ContainerServiceTests {
             // When createContainer
 
             // Then
-            assertThatThrownBy(() -> containerRepository.save(container)).isInstanceOf(RuntimeException.class);
+            assertThatThrownBy(() -> containerService.createContainer(container))
+                    .isInstanceOf(RuntimeException.class);
             verify(containerRepository, times(1)).save(container);
         }
 

--- a/src/test/java/com/practice/portcontainertrackingbackend/unit/application/ContainerServiceTests.java
+++ b/src/test/java/com/practice/portcontainertrackingbackend/unit/application/ContainerServiceTests.java
@@ -67,6 +67,18 @@ public class ContainerServiceTests {
             assertThatThrownBy(() -> containerRepository.save(container)).isInstanceOf(RuntimeException.class);
             verify(containerRepository, times(1)).save(container);
         }
+
+        @Test
+        void shouldThrowExceptionForInvalidObjectWithNullFields() {
+            // Given invalid object
+            container.setCode(null);
+            container.setStatus(null);
+
+            // When And Then
+            assertThatThrownBy(() -> containerService.createContainer(container))
+                    .isInstanceOf(IllegalArgumentException.class);
+            verify(containerRepository, times(0)).save(container);
+        }
     }
 
     @Nested

--- a/src/test/java/com/practice/portcontainertrackingbackend/unit/presentation/controllers/ContainerControllerTests.java
+++ b/src/test/java/com/practice/portcontainertrackingbackend/unit/presentation/controllers/ContainerControllerTests.java
@@ -86,12 +86,28 @@ public class ContainerControllerTests {
         @Test
         void shouldReturnBadRequest400WhenCreatingInvalidObject() throws Exception {
             // Given
-            given(containerService.createContainer(any(Container.class))).willThrow(new RuntimeException("Error"));
+            given(containerService.createContainer(any(Container.class)))
+                    .willThrow(new RuntimeException("Unexpected error for create container"));
 
             // When
             ResultActions response = mockMvc.perform(post(serviceCreateUrl)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(""));
+
+            // Then
+            response.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void shouldReturnBadRequest400WhenCreatingObjectWithNullFields() throws Exception {
+            // Given
+            given(containerService.createContainer(any(Container.class)))
+                    .willThrow(new IllegalArgumentException("Error in arguments"));
+
+            // When
+            ResultActions response = mockMvc.perform(post(serviceCreateUrl)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"));
 
             // Then
             response.andExpect(status().isBadRequest());


### PR DESCRIPTION
# Description

In this PR, we improve the response of create container for request container with null fields.

# Changes:
- Service Layer: Add validation for throw exception when code or status are null.
- Controller Layer: Add response 400 bad request when throw exception for null fields in create container.
- Tests: Comprehensive test suite covering service and controller layer.


# Testing:
- Unit tests for service and controller layers.
- Integration tests for the controller layer.

# Others
-  update README for usage create container